### PR TITLE
docs: updated to correct the dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
     ```zig
     const spin = b.dependency("spin", .{});
     exe.addModule("spin", spin.module("spin"));
-    exe.linkLibrary(spin_dep.artifact("spin"));
+    exe.linkLibrary(spin.artifact("spin"));
     ```
 
     </details>


### PR DESCRIPTION
Referenced `spin_dep` but that doesn't exist, instead you would have to use just `spin`.